### PR TITLE
Feat: Replace Bitcoin address text with a copy-to-clipboard button

### DIFF
--- a/assets/js/logic.js
+++ b/assets/js/logic.js
@@ -313,6 +313,8 @@
                 // Generate Bitcoin QR Code
                 const btcAddressEl = document.getElementById('bitcoinAddress');
                 const btcQrCodeEl = document.getElementById('bitcoinQrCode');
+                const copyBitcoinAddressBtn = document.getElementById('copyBitcoinAddressBtn');
+
                 if (btcAddressEl && btcQrCodeEl && typeof QRCode !== 'undefined') {
                     const btcAddress = btcAddressEl.textContent.trim();
                     if (btcAddress) {
@@ -324,6 +326,30 @@
                             colorLight : "#ffffff",
                             correctLevel : QRCode.CorrectLevel.H
                         });
+
+                        if (copyBitcoinAddressBtn) {
+                            copyBitcoinAddressBtn.addEventListener('click', async () => {
+                                try {
+                                    await navigator.clipboard.writeText(btcAddress);
+                                    const originalText = copyBitcoinAddressBtn.innerHTML;
+                                    copyBitcoinAddressBtn.innerHTML = `Copied! <i class="bi bi-check-lg"></i>`;
+                                    copyBitcoinAddressBtn.disabled = true;
+
+                                    setTimeout(() => {
+                                        copyBitcoinAddressBtn.innerHTML = originalText;
+                                        copyBitcoinAddressBtn.disabled = false;
+                                    }, 2500);
+                                } catch (err) {
+                                    console.error('Failed to copy Bitcoin address: ', err);
+                                    // Optionally, provide feedback to the user that copy failed
+                                    const originalText = copyBitcoinAddressBtn.innerHTML;
+                                    copyBitcoinAddressBtn.innerHTML = `Copy Failed`;
+                                     setTimeout(() => {
+                                        copyBitcoinAddressBtn.innerHTML = originalText;
+                                    }, 2500);
+                                }
+                            });
+                        }
                     }
                 } else {
                     console.warn("Bitcoin QR Code elements not found or QRCode library not loaded.");

--- a/index.html
+++ b/index.html
@@ -166,10 +166,12 @@
                             <div class="donate-title">Support with Bitcoin</div>
                             <div class="donate-desc mb-2">You can also support me with Bitcoin:</div>
                             <div id="bitcoinQrCode" class="mb-2 mx-auto mx-md-0" style="width: 128px; height: 128px;"></div>
-                            <div class="donate-actions d-flex align-items-center flex-wrap justify-content-center justify-content-md-start">
-                                <span class="donate-btc-label">Address:</span>
-                                <span class="donate-btc" id="bitcoinAddress" style="word-break:break-all;">bc1qhyt2vq0rlc596eee2jgef79fvmm9apm5cz57a3</span>
+                            <div class="donate-actions d-flex flex-column align-items-center align-items-md-start mt-2">
+                                <button class="btn btn-outline-secondary btn-sm" id="copyBitcoinAddressBtn" style="min-width: 128px;">
+                                    <i class="bi bi-clipboard"></i> Copy Address
+                                </button>
                             </div>
+                            <span id="bitcoinAddress" class="d-none">bc1qhyt2vq0rlc596eee2jgef79fvmm9apm5cz57a3</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Removed the visible Bitcoin address string from the UI.
- Added a 'Copy Address' button beneath the Bitcoin QR code.
- Implemented JavaScript functionality to copy the Bitcoin address to the clipboard when the button is clicked.
- Added visual feedback to the button on successful copy (changes to 'Copied!' and then reverts).