### PR TITLE
Docs: Update storage warning message to be more general

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                     </button>
                 </div>
                 <div class="alert alert-warning d-inline-block mt-3" id="storageWarning" style="max-width:600px;">
-                    <strong>Warning:</strong> Your push up count and goal are saved in your browser's local storage. If you clear your browser data or use a different device, your progress will be lost.
+                    <strong>Warning:</strong> Your exercise progress, goals, and personalized settings (like username and theme) are saved in your browser's local storage. Clearing browser data or changing devices will erase this information.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Replaced the specific 'push up count and goal' warning with a more comprehensive message that covers all exercise data and personalized settings stored in local storage. This better reflects the app's current and future capabilities.