### PR TITLE
Fix: Resolve html2canvas screenshot failure due to color-mix()

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -217,7 +217,7 @@ body {
             text-shadow: 0 4px 28px var(--accent-color), 0 2px 0 #fff;
         }
         [data-bs-theme="light"] .counter-display {
-             text-shadow: 0 2px 10px color-mix(in srgb, var(--accent-color) 40%, transparent), 0 1px 0 #555;
+             text-shadow: 0 2px 10px rgba(var(--accent-color-rgb), 0.4), 0 1px 0 #555;
         }
 
 
@@ -251,10 +251,10 @@ body {
 
         [data-bs-theme="dark"] .motivational {
             color: var(--accent-color-light); /* Lighter accent for motivational text in dark */
-            text-shadow: 0 1px 4px color-mix(in srgb, var(--accent-color) 50%, #000);
+            text-shadow: 0 1px 4px var(--accent-color-shadow-dark);
         }
         [data-bs-theme="light"] .motivational {
-            color: color-mix(in srgb, var(--accent-color) 80%, #000); /* Darker shade of accent for light */
+            color: var(--accent-color-darker); /* Darker shade of accent for light */
             text-shadow: none;
         }
 

--- a/assets/js/logic.js
+++ b/assets/js/logic.js
@@ -63,10 +63,10 @@
 
             // --- Accent Color Definitions ---
             const accentColors = {
-                indigo: { main: '#6366f1', light: '#a5b4fc' },
-                green: { main: '#10b981', light: '#6ee7b7' },
-                orange: { main: '#f97316', light: '#fdba74' },
-                purple: { main: '#8b5cf6', light: '#c4b5fd' }
+                indigo: { main: '#6366f1', light: '#a5b4fc', rgb: '99, 102, 241', darker: '#4f52b5', shadowDark: '#313278' },
+                green:  { main: '#10b981', light: '#6ee7b7', rgb: '16, 185, 129', darker: '#0d9467', shadowDark: '#085c40' },
+                orange: { main: '#f97316', light: '#fdba74', rgb: '249, 115, 22', darker: '#c75c12', shadowDark: '#7c3a0b' },
+                purple: { main: '#8b5cf6', light: '#c4b5fd', rgb: '139, 92, 246', darker: '#6f49c5', shadowDark: '#452e7b' }
             };
 
             // --- Utility Functions ---
@@ -133,9 +133,12 @@
                     console.warn(`Accent colour ${accentName} not found. Defaulting to indigo.`);
                     accentName = 'indigo';
                 }
-                const { main, light } = accentColors[accentName];
-                document.documentElement.style.setProperty('--accent-color', main);
-                document.documentElement.style.setProperty('--accent-color-light', light);
+                const selectedAccent = accentColors[accentName];
+                document.documentElement.style.setProperty('--accent-color', selectedAccent.main);
+                document.documentElement.style.setProperty('--accent-color-light', selectedAccent.light);
+                document.documentElement.style.setProperty('--accent-color-rgb', selectedAccent.rgb);
+                document.documentElement.style.setProperty('--accent-color-darker', selectedAccent.darker);
+                document.documentElement.style.setProperty('--accent-color-shadow-dark', selectedAccent.shadowDark);
 
                 // Update body class for potential specific overrides if needed elsewhere
                 // Remove old accent classes


### PR DESCRIPTION
- Identified that the use of the `color-mix()` CSS function was causing `html2canvas` to fail when generating screenshots.
- Modified `assets/js/logic.js`:
    - Extended the `accentColors` object to include pre-calculated `rgb`, `darker`, and `shadowDark` variants for each accent colour.
    - Updated the `applyAccentColor` function to set these new variants as CSS variables (e.g., `--accent-color-rgb`, `--accent-color-darker`).
- Modified `assets/css/style.css`:
    - Replaced all instances of `color-mix()` in text shadow and color properties for `.counter-display` and `.motivational` elements.
    - These styles now use the new CSS variables, effectively achieving the desired visual effects with `html2canvas`-compatible CSS.
- Screenshot functionality has been thoroughly tested and is now working correctly across different themes and accent colours.