### PR TITLE
Refactor: Remove tooltips from counter operation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,35 +76,35 @@
                     <div class="d-flex flex-column align-items-center gap-3 mb-3">
                         <!-- Row 1: Add buttons -->
                         <div class="btn-group w-100" role="group" aria-label="Add">
-                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addOneBtn" data-bs-toggle="tooltip" data-bs-title="Add 1">
+                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addOneBtn">
                                 <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+1</span>
                             </button>
-                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addFiveBtn" data-bs-toggle="tooltip" data-bs-title="Add 5">
+                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addFiveBtn">
                                 <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+5</span>
                             </button>
-                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addTenBtn" data-bs-toggle="tooltip" data-bs-title="Add 10">
+                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addTenBtn">
                                 <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+10</span>
                             </button>
-                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addFiftyBtn" data-bs-toggle="tooltip" data-bs-title="Add 50">
+                            <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addFiftyBtn">
                                 <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+50</span>
                             </button>
                         </div>
                         <!-- Row 2: Subtract buttons -->
                         <div class="btn-group w-100" role="group" aria-label="Subtract">
-                            <button class="btn btn-danger btn-lg flex-fill d-flex align-items-center justify-content-center" id="subtractOneBtn" data-bs-toggle="tooltip" data-bs-title="Subtract 1">
+                            <button class="btn btn-danger btn-lg flex-fill d-flex align-items-center justify-content-center" id="subtractOneBtn">
                                 <i class="bi bi-dash-circle"></i> <span class="ms-2 d-none d-sm-inline">-1</span>
                             </button>
-                            <button class="btn btn-danger btn-lg flex-fill d-flex align-items-center justify-content-center" id="subtractTenBtn" data-bs-toggle="tooltip" data-bs-title="Subtract 10">
+                            <button class="btn btn-danger btn-lg flex-fill d-flex align-items-center justify-content-center" id="subtractTenBtn">
                                 <i class="bi bi-dash-circle"></i> <span class="ms-2 d-none d-sm-inline">-10</span>
                             </button>
                         </div>
                         <hr>
                         <!-- Row 3: Action buttons -->
                         <div class="btn-group w-100" role="group" aria-label="Actions">
-                            <button class="btn btn-info btn-lg flex-fill d-flex align-items-center justify-content-center" id="resetBtn" data-bs-toggle="tooltip" data-bs-title="Reset Counter">
+                            <button class="btn btn-info btn-lg flex-fill d-flex align-items-center justify-content-center" id="resetBtn">
                                 <i class="bi bi-arrow-counterclockwise"></i> <span class="ms-2 d-none d-sm-inline">Reset</span>
                             </button>
-                            <button class="btn btn-warning btn-lg flex-fill d-flex align-items-center justify-content-center" id="setGoalBtn" data-bs-toggle="tooltip" data-bs-title="Set Goal">
+                            <button class="btn btn-warning btn-lg flex-fill d-flex align-items-center justify-content-center" id="setGoalBtn">
                                 <i class="bi bi-flag"></i> <span class="ms-2 d-none d-sm-inline">Set Goal</span>
                             </button>
                         </div>


### PR DESCRIPTION
Removed Bootstrap tooltips from the primary counter action buttons (+1, +5, +10, +50, -1, -10, Reset, Set Goal) to reduce redundancy and simplify the interface, relying on the improved color-coding, icons, and button labels for clarity.