### PR TITLE
UI: Make counter button text labels always visible

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -402,10 +402,10 @@ body {
             }
             .btn-lg .bi {
                 font-size: 1rem; /* Slightly smaller icons */
-                margin-right: 0 !important; /* Remove margin if text is hidden */
+                /* margin-right: 0 !important; /* Removed as ms-2 on span should handle spacing */
             }
-            .btn-lg span.ms-2 { /* Hide text on very small screens by default if it was shown with d-none d-sm-inline */
-                 /* display: none; /* This is handled by bootstrap classes d-none d-sm-inline now */
+            .btn-lg span.ms-2 {
+                /* Text is now always visible, ms-2 provides left margin. Font size is already reduced by .btn-lg rule above. */
             }
             #screenshotArea {
                 padding: 1rem 0.25rem !important; /* Minimal padding */

--- a/index.html
+++ b/index.html
@@ -77,35 +77,35 @@
                         <!-- Row 1: Add buttons -->
                         <div class="btn-group w-100" role="group" aria-label="Add">
                             <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addOneBtn">
-                                <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+1</span>
+                                <i class="bi bi-plus-circle"></i> <span class="ms-2">+1</span>
                             </button>
                             <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addFiveBtn">
-                                <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+5</span>
+                                <i class="bi bi-plus-circle"></i> <span class="ms-2">+5</span>
                             </button>
                             <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addTenBtn">
-                                <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+10</span>
+                                <i class="bi bi-plus-circle"></i> <span class="ms-2">+10</span>
                             </button>
                             <button class="btn btn-primary btn-lg flex-fill d-flex align-items-center justify-content-center" id="addFiftyBtn">
-                                <i class="bi bi-plus-circle"></i> <span class="ms-2 d-none d-sm-inline">+50</span>
+                                <i class="bi bi-plus-circle"></i> <span class="ms-2">+50</span>
                             </button>
                         </div>
                         <!-- Row 2: Subtract buttons -->
                         <div class="btn-group w-100" role="group" aria-label="Subtract">
                             <button class="btn btn-danger btn-lg flex-fill d-flex align-items-center justify-content-center" id="subtractOneBtn">
-                                <i class="bi bi-dash-circle"></i> <span class="ms-2 d-none d-sm-inline">-1</span>
+                                <i class="bi bi-dash-circle"></i> <span class="ms-2">-1</span>
                             </button>
                             <button class="btn btn-danger btn-lg flex-fill d-flex align-items-center justify-content-center" id="subtractTenBtn">
-                                <i class="bi bi-dash-circle"></i> <span class="ms-2 d-none d-sm-inline">-10</span>
+                                <i class="bi bi-dash-circle"></i> <span class="ms-2">-10</span>
                             </button>
                         </div>
                         <hr>
                         <!-- Row 3: Action buttons -->
                         <div class="btn-group w-100" role="group" aria-label="Actions">
                             <button class="btn btn-info btn-lg flex-fill d-flex align-items-center justify-content-center" id="resetBtn">
-                                <i class="bi bi-arrow-counterclockwise"></i> <span class="ms-2 d-none d-sm-inline">Reset</span>
+                                <i class="bi bi-arrow-counterclockwise"></i> <span class="ms-2">Reset</span>
                             </button>
                             <button class="btn btn-warning btn-lg flex-fill d-flex align-items-center justify-content-center" id="setGoalBtn">
-                                <i class="bi bi-flag"></i> <span class="ms-2 d-none d-sm-inline">Set Goal</span>
+                                <i class="bi bi-flag"></i> <span class="ms-2">Set Goal</span>
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
- Modified counter operation buttons in `index.html` to ensure their text labels (e.g., "+1", "Reset") are always visible across all screen sizes by removing `d-none` and `d-sm-inline` classes from the text spans.
- Adjusted CSS for extra-small screens by removing a potentially conflicting icon margin rule, allowing existing responsive styles for padding and font-size to accommodate the always-visible labels.
- This change improves button clarity and recognizability, especially on smaller viewports.