### PR TITLE
Style: Standardize footer button sizes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -458,13 +458,18 @@ body {
         footer a:hover {
             color: #ffd700 !important;
         }
-        footer .btn-outline-light.btn-sm {
-            padding: 0.5rem 1rem;
-            font-size: 0.9rem;
+footer .btn-outline-light {
+    padding: 0.5rem 1.2rem; /* Match #shareBtn padding */
+    font-size: 0.9rem; /* Keeping font-size consistent with previous .btn-sm for these */
+    font-weight: 600; /* Match #shareBtn font-weight */
+    border-radius: 1.5rem; /* Match #shareBtn border-radius */
             color: var(--accent-text-on-dark);
             border-color: var(--accent-text-on-dark);
+    /* Ensure other properties like box-shadow and transition are comparable or defined */
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    transition: background 0.2s, color 0.2s, box-shadow 0.2s;
         }
-        footer .btn-outline-light.btn-sm:hover {
+footer .btn-outline-light:hover {
             background-color: var(--accent-text-on-dark);
             color: var(--accent-color);
         }

--- a/index.html
+++ b/index.html
@@ -145,13 +145,13 @@
     <footer class="text-center py-4" style="background: linear-gradient(90deg, #0d6efd 0%, #6610f2 100%); color: #fff; font-size:1.1rem; font-weight:600; letter-spacing:0.5px; border-radius: 1.5rem 1.5rem 0 0; box-shadow: 0 -2px 16px rgba(13,110,253,0.15); margin-top:2rem;">
         <div class="container">
             <div class="mb-2">
-                <button class="btn btn-outline-light btn-sm shadow-sm" id="shareBtn" style="font-weight:700; border-radius:2rem; transition:background 0.2s;">Share Site</button>
-                <a href="https://github.com/slingJin30/pushupcounter/archive/refs/heads/main.zip" target="_blank" rel="noopener" class="btn btn-outline-light btn-sm d-inline-flex align-items-center gap-2" style="font-weight:700; border-radius:2rem;">
+                <button class="btn btn-outline-light shadow-sm" id="shareBtn">Share Site</button>
+                <a href="https://github.com/slingJin30/pushupcounter/archive/refs/heads/main.zip" target="_blank" rel="noopener" class="btn btn-outline-light d-inline-flex align-items-center gap-2">
                     <i class="bi bi-download"></i> Download ZIP
                 </a>
-                <button id="exportDataBtn" class="btn btn-outline-light btn-sm ms-2" style="font-weight:700; border-radius:2rem;">Export Data</button>
+                <button id="exportDataBtn" class="btn btn-outline-light ms-2">Export Data</button>
                 <input type="file" id="importFile" accept=".json" style="display: none;">
-                <button id="importDataBtn" class="btn btn-outline-light btn-sm ms-2" style="font-weight:700; border-radius:2rem;">Import Data</button>
+                <button id="importDataBtn" class="btn btn-outline-light ms-2">Import Data</button>
             </div>
             <div class="donate-card mx-auto my-3" style="max-width: 540px;">
                 <div class="donate-content row g-3 align-items-stretch flex-md-nowrap justify-content-center">


### PR DESCRIPTION
Makes the 'Download ZIP', 'Export Data', and 'Import Data' buttons in the footer consistent in size with the 'Share Site' button.

- Removed `btn-sm` and inline styles from relevant footer buttons in HTML.
- Updated CSS for `footer .btn-outline-light` to apply consistent padding, font-weight, and border-radius, aligning with `#shareBtn` dimensions.